### PR TITLE
Windows, linker error: multiple implementation of last_error() function due to multiple inclusion of header files within a single project 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0.0)
 
-project(dynalo)
+project(dynalo LANGUAGES CXX)
 
 #set(CMAKE_CXX_STANDARD          11 )
 #set(CMAKE_CXX_STANDARD_REQUIRED ON )

--- a/include/dynalo/detail/windows/dynalo.hpp
+++ b/include/dynalo/detail/windows/dynalo.hpp
@@ -9,7 +9,7 @@
 namespace dynalo { namespace detail
 {
 
-std::string last_error()
+inline std::string last_error()
 {
     // https://msdn.microsoft.com/en-us/library/ms680582%28VS.85%29.aspx
     LPVOID lpMsgBuf;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0.0)
 
-project(dynalo-test)
+project(dynalo-test LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD          11 )
 set(CMAKE_CXX_STANDARD_REQUIRED ON )


### PR DESCRIPTION
Related to issue #5 