### PR TITLE
fix warnings and update cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,7 @@ project(dynalo)
 
 option(CLEAN_BUILD "Clean build with no warnings allowed" OFF)
 message(STATUS "Clean build, warnings are not allowed: " ${CLEAN_BUILD})
-
-include(CMakeDependentOption)
-
-# do not build tests if included as a subdirectory
-cmake_dependent_option(BUILD_TESTS "Build Tests" ON
-        "NOT hasParent" OFF)
+option(BUILD_TESTS "Build tests for ${PROJECT_NAME}: " ON)
 
 if (${CLEAN_BUILD})
     if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
@@ -78,7 +73,10 @@ install(
     DESTINATION "${CONFIG_PACKAGE_INSTALL_LOCATION}"
 )
 
-if (BUILD_TESTS)
+get_directory_property(IS_EXCLUDED ${CMAKE_CURRENT_SOURCE_DIR} EXCLUDE_FROM_ALL)
+
+if (NOT IS_EXCLUDED AND BUILD_TESTS)
+    message(STATUS "Building tests for ${PROJECT_NAME}")
     enable_testing()
     add_subdirectory(test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,20 @@ project(dynalo)
 #set(CMAKE_CXX_STANDARD_REQUIRED ON )
 #set(CMAKE_CXX_EXTENSIONS        OFF)
 
+option(CLEAN_BUILD "Clean build with no warnings allowed" OFF)
+message(STATUS "Clean build, warnings are not allowed: " ${CLEAN_BUILD})
+
+if (${CLEAN_BUILD})
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        add_compile_options(/W4 /WX)
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        add_compile_options(-Wall -Wextra -pedantic -Werror)
+    else()
+        # TODO: implement flags for other compilers
+        message(STATUS "CLEAN_BUILD is not supported for ${CMAKE_CXX_COMPILER_ID}")
+    endif()
+endif()
+
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,4 +72,5 @@ install(
     DESTINATION "${CONFIG_PACKAGE_INSTALL_LOCATION}"
 )
 
+enable_testing()
 add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,9 @@ option(CLEAN_BUILD "Clean build with no warnings allowed" OFF)
 message(STATUS "Clean build, warnings are not allowed: " ${CLEAN_BUILD})
 
 if (${CLEAN_BUILD})
-    if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
         add_compile_options(/W4 /WX)
-    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
         add_compile_options(-Wall -Wextra -pedantic -Werror)
     else()
         # TODO: implement flags for other compilers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,12 @@ project(dynalo)
 option(CLEAN_BUILD "Clean build with no warnings allowed" OFF)
 message(STATUS "Clean build, warnings are not allowed: " ${CLEAN_BUILD})
 
+include(CMakeDependentOption)
+
+# do not build tests if included as a subdirectory
+cmake_dependent_option(BUILD_TESTS "Build Tests" ON
+        "NOT hasParent" OFF)
+
 if (${CLEAN_BUILD})
     if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
         add_compile_options(/W4 /WX)
@@ -72,5 +78,7 @@ install(
     DESTINATION "${CONFIG_PACKAGE_INSTALL_LOCATION}"
 )
 
-enable_testing()
-add_subdirectory(test)
+if (BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(test)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ install(
     DESTINATION "${CONFIG_PACKAGE_INSTALL_LOCATION}"
 )
 
-get_directory_property(IS_EXCLUDED ${CMAKE_CURRENT_SOURCE_DIR} EXCLUDE_FROM_ALL)
+get_directory_property(IS_EXCLUDED EXCLUDE_FROM_ALL)
 
 if (NOT IS_EXCLUDED AND BUILD_TESTS)
     message(STATUS "Building tests for ${PROJECT_NAME}")

--- a/include/dynalo/detail/linux/dynalo.hpp
+++ b/include/dynalo/detail/linux/dynalo.hpp
@@ -64,7 +64,9 @@ FunctionSignature* get_function(native::handle lib_handle, const std::string& fu
         throw std::runtime_error(std::string("Failed to get [func_name:") + func_name + "]: " + last_error());
     }
 
-    return reinterpret_cast<FunctionSignature*>(func_ptr);
+// TODO: disable optimization for these lines since it is UB
+    void **intermediate_ptr = reinterpret_cast<void**>(&func_ptr);
+    return reinterpret_cast<FunctionSignature*>(*intermediate_ptr);
 }
 
 }}

--- a/include/dynalo/detail/windows/dynalo.hpp
+++ b/include/dynalo/detail/windows/dynalo.hpp
@@ -92,7 +92,9 @@ FunctionSignature* get_function(native::handle lib_handle, const std::string& fu
         throw std::runtime_error(std::string("Failed to get [func_name:") + func_name + "]: " + last_error());
     }
 
-    return reinterpret_cast<FunctionSignature*>(func_ptr);
+// TODO: disable optimization for these lines since it is UB
+    void **intermediate_ptr = reinterpret_cast<void**>(&func_ptr);
+    return reinterpret_cast<FunctionSignature*>(*intermediate_ptr);
 }
 
 }}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required(VERSION 3.0.0)
+#cmake_minimum_required(VERSION 3.0.0)
 
-project(dynalo-test)
+# project(dynalo-test)
 
 set(CMAKE_CXX_STANDARD          11 )
 set(CMAKE_CXX_STANDARD_REQUIRED ON )
@@ -13,7 +13,6 @@ add_library(shared SHARED shared.cpp)
 
 add_dependencies(loader shared)
 
-enable_testing()
-add_test(NAME all_tests COMMAND
+add_test(NAME loader COMMAND
     "$<TARGET_FILE:loader>" "$<TARGET_FILE_DIR:shared>" "shared"
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,5 +14,5 @@ add_library(shared SHARED shared.cpp)
 add_dependencies(loader shared)
 
 add_test(NAME loader COMMAND
-    "$<TARGET_FILE:loader>" "$<TARGET_FILE_DIR:shared>" "shared"
+    "$<TARGET_FILE:loader>" "$<TARGET_FILE:shared>"
 )

--- a/test/loader.cpp
+++ b/test/loader.cpp
@@ -4,7 +4,7 @@
 #include <sstream>
 
 // usage: loader "path/to/shared/lib/dir"
-int main(int argc, char* argv[])
+int main(int /*argc*/, char* argv[])
 {
     dynalo::library lib(std::string(argv[1]) + "/" + dynalo::to_native_name("shared"));
 

--- a/test/loader.cpp
+++ b/test/loader.cpp
@@ -1,17 +1,33 @@
 #include <dynalo/dynalo.hpp>
 
 #include <cstdint>
+#include <iostream>
 #include <sstream>
 
 // usage: loader "path/to/shared/lib/dir"
-int main(int /*argc*/, char* argv[])
+int main(int argc, char* argv[])
 {
-    dynalo::library lib(std::string(argv[1]) + "/" + dynalo::to_native_name("shared"));
+    if (argc < 2)
+    {
+        std::cerr << "No path for a dynamic library was provided.\nUsage: ./loader path_to_dyn_lib" << std::endl;
+    }
+    try
+    {
+        dynalo::library lib(std::string(argv[1]) + "/" + dynalo::to_native_name("shared"));
 
-    auto add_integers  = lib.get_function<int32_t(const int32_t, const int32_t)>("add_integers");
-    auto print_message = lib.get_function<void(const char*)>("print_message");
+        auto add_integers  = lib.get_function<int32_t(const int32_t, const int32_t)>("add_integers");
+        auto print_message = lib.get_function<void(const char*)>("print_message");
 
-    std::ostringstream oss;
-    oss << "it works: " << add_integers(1, 2);
-    print_message(oss.str().c_str());
+        std::ostringstream oss;
+        oss << "it works: " << add_integers(1, 2);
+        print_message(oss.str().c_str());
+
+        return 0;
+    }
+    catch (const std::exception& error)
+    {
+        std::cerr << "Test failed: " << error.what() << std::endl;
+    }
+
+    return -1;
 }

--- a/test/loader.cpp
+++ b/test/loader.cpp
@@ -13,7 +13,7 @@ int main(int argc, char* argv[])
     }
     try
     {
-        dynalo::library lib(std::string(argv[1]) + "/" + dynalo::to_native_name("shared"));
+        dynalo::library lib(argv[1]);
 
         auto add_integers  = lib.get_function<int32_t(const int32_t, const int32_t)>("add_integers");
         auto print_message = lib.get_function<void(const char*)>("print_message");


### PR DESCRIPTION
1) added a workaround on function pointer casting, since direct usage of `reinterpret_cast` results in a warning. That prevents the usage of a package in the project that treats warnings as errors.
2) added `CLEAN_BUILD` option defaulted to `OFF`. If `ON`, the project will compile with all the warnings and treat them as errors. Works for MSVC and GNU. 
3) modified tests:
   - renamed test target from `all_tests` to `loader`, since it is ambiguous and `ALL_TESTS` is used by cmake
   - moved `enable_testing` to the root CMakeLists.txt as it is required by documentation.
   - added option `BUILD_TESTS` defaulted to `ON`
   - added test in cmake for `EXCLUDE_FROM_ALL` property on directory. If tests are enabled, parent project's test will fail because it won't build executables for testing.  If the property is detected to be `TRUE`, no tests will be built.
   - added check for input arguments (checking `argc`) in `loader` test. Also added try-catch block and return `-1` if test fails.
   - modified test to accept 1 argument as an absolute path to shared library. Since the test is now invoked with `$<TARGET_FILE:shared>` which provides an absolute path to the binary, the test works without errors for shared library name. 